### PR TITLE
Replace auth_browseruid() with session_id()

### DIFF
--- a/action.php
+++ b/action.php
@@ -18,19 +18,13 @@ class action_plugin_anonip extends DokuWiki_Action_Plugin {
     }
 
     public function handle_dokuwiki_started(Doku_Event &$event, $param) {
-        // is the incoming IP already anonymized by the webserver?
-        if($_SERVER['REMOTE_ADDR'] == '127.0.0.1'){
-            // try to use the session ID as identifier
-            $ses = session_id();
-            if(!$ses){
-                // no session running, randomize
-                $ses = mt_rand();
-            }
-            $uid = md5($ses);
-        }else{
-            // Use IP + Browser Data
-            $uid = md5(auth_browseruid());
+        // try to use the session ID as identifier
+        $ses = session_id();
+        if (!$ses) {
+            // no session running, randomize
+            $ses = mt_rand();
         }
+        $uid = md5($ses);
 
         // build pseudo IPv6 (local)
         $ip = 'fe80:'.substr($uid,0,4).

--- a/action.php
+++ b/action.php
@@ -24,7 +24,7 @@ class action_plugin_anonip extends DokuWiki_Action_Plugin {
             // no session running, randomize
             $ses = mt_rand();
         }
-        $uid = md5($ses);
+        $uid = hash('sha256', $ses);
 
         // build pseudo IPv6 (local)
         $ip = 'fe80:'.substr($uid,0,4).

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   anonip
 author Andreas Gohr
 email  andi@splitbrain.org
-date   2016-07-06
+date   2020-09-28
 name   anonip plugin
 desc   Anonymize all IP addresses
 url    http://www.dokuwiki.org/plugin:anonip


### PR DESCRIPTION
Use session_id() in all cases, to protect against brute-forcing the information included in auth_browseruid(), as discussed in https://forum.dokuwiki.org/d/18284-dont-store-ip-addresses/5

Also, use SHA256 instead of MD5.

I tested this with the latest development snapshot, it works as intended.